### PR TITLE
LRU cache for the entity manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ git-version = "0.3.5"
 hex = "0.4.3"
 humantime = "2.1.0"
 log = "0.4.17"
+lru = "0.11.0"
 postcard = { version = "1.0.6", default-features = false }
 scopeguard = "1.1"
 serde = "1.0.151"

--- a/akka-persistence-rs/Cargo.toml
+++ b/akka-persistence-rs/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = { workspace = true }
+lru = { workspace = true }
 tokio = { workspace = true, features = [
     "sync",
     "macros",

--- a/akka-persistence-rs/src/effect.rs
+++ b/akka-persistence-rs/src/effect.rs
@@ -1,9 +1,9 @@
 //! Effects that are lazily performed as a result of performing a command
 //! of an entity. Effects can be chained with other effects.
 
-use std::{collections::HashMap, future::Future, io, marker::PhantomData};
-
 use async_trait::async_trait;
+use lru::LruCache;
+use std::{future::Future, io, marker::PhantomData};
 use tokio::sync::oneshot;
 
 use crate::{entity::EventSourcedBehavior, entity_manager::RecordAdapter, EntityId, Record};
@@ -28,10 +28,10 @@ where
         &mut self,
         behavior: &B,
         adapter: &mut (dyn RecordAdapter<B::Event> + Send),
-        entities: &mut HashMap<EntityId, B::State>,
+        entities: &mut LruCache<EntityId, B::State>,
         entity_id: EntityId,
         prev_result: Result,
-        update_entity: &mut (dyn for<'a> FnMut(&'a mut HashMap<EntityId, B::State>, Record<B::Event>)
+        update_entity: &mut (dyn for<'a> FnMut(&'a mut LruCache<EntityId, B::State>, Record<B::Event>)
                   + Send),
     ) -> Result;
 }
@@ -55,10 +55,10 @@ where
         &mut self,
         behavior: &B,
         adapter: &mut (dyn RecordAdapter<B::Event> + Send),
-        entities: &mut HashMap<EntityId, B::State>,
+        entities: &mut LruCache<EntityId, B::State>,
         entity_id: EntityId,
         prev_result: Result,
-        update_entity: &mut (dyn for<'a> FnMut(&'a mut HashMap<EntityId, B::State>, Record<B::Event>)
+        update_entity: &mut (dyn for<'a> FnMut(&'a mut LruCache<EntityId, B::State>, Record<B::Event>)
                   + Send),
     ) -> Result {
         let r = self
@@ -139,10 +139,10 @@ where
         &mut self,
         _behavior: &B,
         adapter: &mut (dyn RecordAdapter<B::Event> + Send),
-        entities: &mut HashMap<EntityId, B::State>,
+        entities: &mut LruCache<EntityId, B::State>,
         entity_id: EntityId,
         prev_result: Result,
-        update_entity: &mut (dyn for<'a> FnMut(&'a mut HashMap<EntityId, B::State>, Record<B::Event>)
+        update_entity: &mut (dyn for<'a> FnMut(&'a mut LruCache<EntityId, B::State>, Record<B::Event>)
                   + Send),
     ) -> Result {
         if prev_result.is_ok() {
@@ -222,10 +222,10 @@ where
         &mut self,
         _behavior: &B,
         _adapter: &mut (dyn RecordAdapter<B::Event> + Send),
-        _entities: &mut HashMap<EntityId, B::State>,
+        _entities: &mut LruCache<EntityId, B::State>,
         _entity_id: EntityId,
         prev_result: Result,
-        _update_entity: &mut (dyn for<'a> FnMut(&'a mut HashMap<EntityId, B::State>, Record<B::Event>)
+        _update_entity: &mut (dyn for<'a> FnMut(&'a mut LruCache<EntityId, B::State>, Record<B::Event>)
                   + Send),
     ) -> Result {
         if prev_result.is_ok() {
@@ -274,10 +274,10 @@ where
         &mut self,
         behavior: &B,
         _adapter: &mut (dyn RecordAdapter<B::Event> + Send),
-        entities: &mut HashMap<EntityId, B::State>,
+        entities: &mut LruCache<EntityId, B::State>,
         entity_id: EntityId,
         prev_result: Result,
-        _update_entity: &mut (dyn for<'a> FnMut(&'a mut HashMap<EntityId, B::State>, Record<B::Event>)
+        _update_entity: &mut (dyn for<'a> FnMut(&'a mut LruCache<EntityId, B::State>, Record<B::Event>)
                   + Send),
     ) -> Result {
         let f = self.f.take();
@@ -332,10 +332,10 @@ where
         &mut self,
         _behavior: &B,
         _adapter: &mut (dyn RecordAdapter<B::Event> + Send),
-        _entities: &mut HashMap<EntityId, B::State>,
+        _entities: &mut LruCache<EntityId, B::State>,
         _entity_id: EntityId,
         _prev_result: Result,
-        _update_entity: &mut (dyn for<'a> FnMut(&'a mut HashMap<EntityId, B::State>, Record<B::Event>)
+        _update_entity: &mut (dyn for<'a> FnMut(&'a mut LruCache<EntityId, B::State>, Record<B::Event>)
                   + Send),
     ) -> Result {
         Ok(())


### PR DESCRIPTION
The entity manager now uses a simple and evolved LRU cache given that we're in control of the concurrency aspects.

I also upped the working set (capacity) to 10. We of course still permit the developer to override that, and I've not forgotten about the potential for a config struct as we move forward.