### PR TITLE
Encryption for commit log storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 members = [
     "akka-persistence-rs",
-    "akka-persistence-rs-filelog",
+    "akka-persistence-rs-commitlog",
     "examples/iot-service",
 ]
 
@@ -18,9 +18,11 @@ hex = "0.4.3"
 humantime = "2.1.0"
 log = "0.4.17"
 postcard = { version = "1.0.6", default-features = false }
+rand = "0.8"
 scopeguard = "1.1"
 serde = "1.0.151"
 streambed = { git = "https://github.com/streambed/streambed-rs.git", rev = "4b7e1561666bc1860339d27f5abf9be246ef5ad9" }
+streambed-confidant = { git = "https://github.com/streambed/streambed-rs.git", rev = "4b7e1561666bc1860339d27f5abf9be246ef5ad9" }
 streambed-logged = { git = "https://github.com/streambed/streambed-rs.git", rev = "4b7e1561666bc1860339d27f5abf9be246ef5ad9" }
 test-log = "0.2.11"
 tokio = "1.23.0"

--- a/akka-persistence-rs-commitlog/Cargo.toml
+++ b/akka-persistence-rs-commitlog/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "akka-persistence-rs-filelog"
+name = "akka-persistence-rs-commitlog"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,6 +7,7 @@ edition = "2021"
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 ciborium = { workspace = true, optional = true }
+rand = { workspace = true }
 serde = { workspace = true }
 streambed = { workspace = true }
 streambed-logged = { workspace = true }

--- a/akka-persistence-rs-commitlog/README.md
+++ b/akka-persistence-rs-commitlog/README.md
@@ -1,0 +1,11 @@
+# Akka Persistence adapter for Streambed commit logs
+
+This crate adapts Streambed's CommitLog and SecretStore traits for the purposes of it being used with Akka Persistence of akka-edge-rs.
+
+[Streambed](https://github.com/streambed/streambed-rs) provides an implementation of a commit log named ["Logged"](https://github.com/streambed/streambed-rs/tree/main/streambed-logged). 
+Logged is a library focused on conserving storage and is particularly suited for use at the edge that uses flash based
+storage. Other forms of commit log are also supported by Streabmed, including a [Kafka](https://kafka.apache.org/)-like HTTP interface.
+
+The encryption/decryption of records stored in a commit log are also handled through Streambed's SecretStore. Streambed also provides an implementation
+of a file-based secret store named ["Confidant"](https://github.com/streambed/streambed-rs/tree/main/streambed-confidant). Confidant is also particularly
+suited for use at the edge where flash storage is also used. Other forms of the secret store are supported, including [Hashicorp's Vault](https://www.vaultproject.io/).

--- a/akka-persistence-rs-filelog/README.md
+++ b/akka-persistence-rs-filelog/README.md
@@ -1,8 +1,0 @@
-# Akka Persistence adapter for Streambed Filelog
-
-[Streambed](https://github.com/streambed/streambed-rs) provides an implementation of a commit log named ["Logged"](https://github.com/streambed/streambed-rs/tree/main/streambed-logged). 
-Logged is a library focused on conserving storage and is particularly suited for use at the edge that uses flash based
-storage.
-
-This crate adapts Logged for the purposes of it being used with Akka Persistence of 
-akka-edge-rs.

--- a/examples/iot-service/Cargo.toml
+++ b/examples/iot-service/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-stream = { workspace = true }
+async-trait = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 env_logger = { workspace = true }
@@ -15,9 +16,11 @@ log = { workspace = true }
 postcard = { workspace = true, default-features = false, features = [
     "use-std",
 ] }
+rand = { workspace = true }
 scopeguard = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 streambed = { workspace = true }
+streambed-confidant = { workspace = true }
 streambed-logged = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
@@ -25,7 +28,7 @@ tokio-util = { workspace = true, features = ["codec"] }
 warp = { workspace = true }
 
 akka-persistence-rs = { path = "../../akka-persistence-rs" }
-akka-persistence-rs-filelog = { path = "../../akka-persistence-rs-filelog", features = [
+akka-persistence-rs-commitlog = { path = "../../akka-persistence-rs-commitlog", features = [
     "cbor",
 ] }
 

--- a/examples/iot-service/src/main.rs
+++ b/examples/iot-service/src/main.rs
@@ -1,8 +1,11 @@
-use std::{error::Error, net::SocketAddr};
+use std::{collections::HashMap, error::Error, net::SocketAddr};
 
 use clap::Parser;
 use git_version::git_version;
 use log::info;
+use rand::RngCore;
+use streambed::secret_store::{SecretData, SecretStore};
+use streambed_confidant::{args::SsArgs, FileSecretStore};
 use streambed_logged::{args::CommitLogArgs, FileLog};
 use tokio::{net::UdpSocket, sync::mpsc};
 
@@ -24,6 +27,10 @@ struct Args {
     #[clap(env, long, default_value = "127.0.0.1:8080")]
     http_addr: SocketAddr,
 
+    /// Logged commit log args
+    #[clap(flatten)]
+    ss_args: SsArgs,
+
     /// A socket address for receiving telemetry from our ficticious
     /// sensor.
     #[clap(env, long, default_value = "127.0.0.1:8081")]
@@ -37,6 +44,47 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
 
     env_logger::builder().format_timestamp_millis().init();
+
+    // Setup and authenticate our service with the secret store
+    let ss = {
+        let line = streambed::read_line(std::io::stdin()).unwrap();
+        assert!(!line.is_empty(), "Failed to source a line from stdin");
+        let (root_secret, ss_secret_id) = line.split_at(32);
+        let root_secret = hex::decode(root_secret).unwrap();
+
+        let ss = FileSecretStore::new(
+            args.ss_args.ss_root_path,
+            &root_secret.try_into().unwrap(),
+            args.ss_args.ss_unauthorized_timeout.into(),
+            args.ss_args.ss_max_secrets,
+            args.ss_args.ss_ttl_field.as_deref(),
+        );
+
+        ss.approle_auth(&args.ss_args.ss_role_id, ss_secret_id)
+            .await
+            .unwrap();
+
+        ss
+    };
+
+    // To keep things straightforward for this example, we will use
+    // a random key to encrypt our events where we've not already
+    // written a key. In a real-world scenario, our temperature entities
+    // would be provisioned using some out-of-band mechanism. Upon
+    // provisioning, the secret store would be updated with a secret
+    // at a path that is specific for the entity.
+    let temperature_events_key_secret_path =
+        format!("{}/secrets.temperature-events.key", args.ss_args.ss_ns);
+
+    if let Ok(None) = ss.get_secret(&temperature_events_key_secret_path).await {
+        // If we can't write this initial secret then all bets are off
+        let mut key = vec![0; 16];
+        rand::thread_rng().fill_bytes(&mut key);
+        let data = HashMap::from([("value".to_string(), hex::encode(key))]);
+        ss.create_secret(&temperature_events_key_secret_path, SecretData { data })
+            .await
+            .unwrap();
+    }
 
     // Set up the commit log
     let cl = FileLog::new(args.cl_args.cl_root_path.clone());
@@ -60,7 +108,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     info!("IoT service ready");
 
-    tokio::spawn(async { temperature::task(cl, temperature_command_receiver).await })
-        .await?
-        .map_err(|e| e.into())
+    tokio::spawn(async {
+        temperature::task(
+            cl,
+            ss,
+            temperature_events_key_secret_path,
+            temperature_command_receiver,
+        )
+        .await
+    })
+    .await?
+    .map_err(|e| e.into())
 }


### PR DESCRIPTION
Provides the hooks to encrypt/decrypt records for the marshaler and updates the example to illustrate. Encrypting data at rest with the commit log is important and was initially imposed by working with large vendors at the edge. Streambed provides rich support for encryption so this does not burden a developer.

Another driver for incorporating encryption was to ensure that the traits we have can support it. It turns out that we needed to be more async around the marshaling, so good to understand this now.

I have also made the file log module generic over CommitLog and, now, an associated SecretStore. Streambed has a file secret store named "Confidant", and also provides an implementation for connecting with Hashicorp Vault. Very little effort was expended in accomodating more generics to this module.