### PR TITLE
MIPS32 config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,10 @@ warp = "0.3"
 [profile.bench-debug]
 inherits = "release"
 debug = true
+
+[profile.release]
+codegen-units = 1 # better optimizations
+lto = true        # better optimizations
+opt-level = 'z'   # Optimize for size
+panic = "abort"   # No unwinding or helpful backtrace
+strip = true      # No debug symbols etc

--- a/examples/iot-service/.cargo/config.toml
+++ b/examples/iot-service/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.mipsel-unknown-linux-musl]
+linker = "mipsel-openwrt-linux-musl-gcc"


### PR DESCRIPTION
Provides config to target MIPS32.

Here's an example of the `iot-service` having been built and deployed to run on the Cuprous Secured Edge Gateway (single 500mHz MIPS32 core, 128MiB memory, 32MB of flash).

![CBB00361-94FB-4139-91AF-CFB1542F674A_1_105_c](https://github.com/lightbend/akka-edge-rs/assets/694893/6fe6ca81-55eb-4225-8d3a-f7f507b21f5a)

```
root@OpenWrt:/tmp# iot-service -h
This service receives IoT data re. temperature, stores it in the commit log keyed by its sensor id, and provides an HTTP interface to access it

Usage: iot-service [OPTIONS] --ss-role-id <SS_ROLE_ID>

Options:
      --cl-idle-timeout <CL_IDLE_TIMEOUT>
          The amount of time to indicate that no more events are immediately available from the Commit Log endpoint [env: CL_IDLE_TIMEOUT=] [default: 100ms]
      --cl-namespace <CL_NAMESPACE>
          A namespace to connect to [env: CL_NAMESPACE=]
      --cl-ns <CL_NS>
          A namespace to use when communicating with the Commit Log [env: CL_NS=] [default: default]
      --cl-root-path <CL_ROOT_PATH>
          The location of all topics in the Commit Log [env: CL_ROOT_PATH=] [default: /var/lib/logged]
      --event-consumer-addr <EVENT_CONSUMER_ADDR>
          A socket address for connecting to a GRPC event consuming service for temperature observations [env: EVENT_CONSUMER_ADDR=] [default: http://127.0.0.1:8101]
      --event-producer-addr <EVENT_PRODUCER_ADDR>
          A socket address for connecting to a GRPC event producing service for registrations. Only relevant when building the example with the "grpc" feature [env: EVENT_PRODUCER_ADDR=] [default: http://127.0.0.1:8101]
      --http-addr <HTTP_ADDR>
          A socket address for serving our HTTP web service requests [env: HTTP_ADDR=] [default: 127.0.0.1:8080]
      --ss-max-secrets <SS_MAX_SECRETS>
          The max number of Vault Secret Store secrets to retain by our cache at any time. Least Recently Used (LRU) secrets will be evicted from our cache once this value is exceeded [env: SS_MAX_SECRETS=] [default: 10000]
      --ss-ns <SS_NS>
          A namespace to use when communicating with the Vault Secret Store [env: SS_NS=] [default: default]
      --ss-role-id <SS_ROLE_ID>
          The Secret Store role_id to use for approle authentication [env: SS_ROLE_ID=]
      --ss-root-path <SS_ROOT_PATH>
          The location of all secrets belonging to confidant. The recommendation is to create a user for confidant and a requirement is to remove group and world permissions. Then, use ACLs to express further access conditions [env: SS_ROOT_PATH=] [default: /var/lib/confidant]
      --ss-ttl-field <SS_TTL_FIELD>
          A data field to used in place of Vault's lease_duration field. Time will be interpreted as a humantime string e.g. "1m", "1s" etc. Note that v2 of the Vault server does not appear to populate the lease_duration field for the KV secret store any longer. Instead, we can use a "ttl" field from the data [env: SS_TTL_FIELD=]
      --ss-unauthorized-timeout <SS_UNAUTHORIZED_TIMEOUT>
          How long we wait until re-requesting the Vault Secret Store server for an unauthorized secret again [env: SS_UNAUTHORIZED_TIMEOUT=] [default: 1m]
      --udp-addr <UDP_ADDR>
          A socket address for receiving telemetry from our ficticious sensor [env: UDP_ADDR=] [default: 127.0.0.1:8081]
  -h, --help
          Print help
  -V, --version
          Print version
```

The release build image size is around 3.8MB, which is good. I see around 5MB in production given a fully-functional service.