### PR TITLE
gRPC connection flexibility

### DIFF
--- a/examples/iot-service/src/registration_projection.rs
+++ b/examples/iot-service/src/registration_projection.rs
@@ -7,6 +7,7 @@ use std::{path::PathBuf, time::Duration};
 use streambed_confidant::FileSecretStore;
 use streambed_logged::FileLog;
 use tokio::sync::{mpsc, oneshot};
+use tonic::transport::Channel;
 use tonic::transport::Uri;
 
 use crate::registration;
@@ -48,7 +49,8 @@ pub async fn task(
         .await
     });
 
-    let source_provider = GrpcSourceProvider::new(event_producer_addr, stream_id, offset_store);
+    let channel = Channel::builder(event_producer_addr);
+    let source_provider = GrpcSourceProvider::new(|| channel.connect(), stream_id, offset_store);
 
     // Declare a handler to forward projection events on to the temperature entity.
 

--- a/examples/iot-service/src/temperature_production.rs
+++ b/examples/iot-service/src/temperature_production.rs
@@ -13,7 +13,7 @@ use streambed::commit_log::Topic;
 use streambed_confidant::FileSecretStore;
 use streambed_logged::FileLog;
 use tokio::sync::{mpsc, oneshot};
-use tonic::transport::Uri;
+use tonic::transport::{Channel, Uri};
 
 // Apply sensor observations to a remote consumer.
 pub async fn task(
@@ -35,8 +35,9 @@ pub async fn task(
 
     let (_task_kill_switch, task_kill_switch_receiver) = oneshot::channel();
     tokio::spawn(async {
+        let channel = Channel::builder(event_consumer_addr);
         akka_projection_rs_grpc::producer::run(
-            event_consumer_addr,
+            || channel.connect(),
             OriginId::from("edge-iot-service"),
             StreamId::from("temperature-events"),
             grpc_producer_receiver,


### PR DESCRIPTION
Provides flexibility in the types of connection that can be established e.g. http + TLS and Unix Domain Sockets can be established for gRPC connectivity, as well as the regular http ones. For an insight on how this should work: https://github.com/hyperium/tonic/blob/master/examples/src/tls_client_auth/client.rs

Fixes #26 
