### PR TITLE
Introduces dynamic filtering

### DIFF
--- a/akka-projection-rs/src/consumer_filter.rs
+++ b/akka-projection-rs/src/consumer_filter.rs
@@ -28,6 +28,7 @@
 use akka_persistence_rs::EntityId;
 use smol_str::SmolStr;
 
+#[derive(Clone)]
 pub struct EntityIdOffset {
     pub entity_id: EntityId,
     // If this is defined (> 0) events are replayed from the given
@@ -48,6 +49,7 @@ pub type TopicMatcher = SmolStr;
 /// If an exclude criteria is matching the include criteria are evaluated.
 ///   If no matching include criteria the event is discarded.
 ///   If matching include criteria the event is emitted.
+#[derive(Clone)]
 pub enum FilterCriteria {
     /// Exclude events with any of the given tags, unless there is a
     /// matching include filter that overrides the exclude.


### PR DESCRIPTION
Filtering can be specified dynamically through the use of a Tokio watch channel. Watch is known as "spmc" (Single Producer, Multi Consumer), and has the special property that it remembers the last value sent. If multiple producers were required then the watch could easily be composed within an mpsc (Multi Producer, Single Consumer).

The test illustrates how both an initial filter can be set up, and how it can then be subsequently replaced. The tests have also been enhanced to assert that both the initial request and a filter update are conveyed to the remote producer.
