### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ js-sys = "0.3.60"
 log = "0.4.17"
 lru = "0.11.0"
 mqtt-protocol = "0.11.2"
-postcard = { version = "1.0.6", default-features = false }
+postcard = { version = "1.0.8", default-features = false }
 prost = { version = "0.12.0" }
 prost-build = { version = "0.12.0" }
 prost-types = { version = "0.12.0" }
@@ -43,10 +43,10 @@ scopeguard = "1.1"
 serde = "1.0.151"
 serde_json = "1.0.107"
 smol_str = "0.2.0"
-streambed = { git = "https://github.com/streambed/streambed-rs.git", rev = "d343171f7ec85cc028674115c8df30150b741ef6" }
-streambed-confidant = { git = "https://github.com/streambed/streambed-rs.git", rev = "d343171f7ec85cc028674115c8df30150b741ef6" }
-streambed-logged = { git = "https://github.com/streambed/streambed-rs.git", rev = "d343171f7ec85cc028674115c8df30150b741ef6" }
-streambed-storage = { git = "https://github.com/streambed/streambed-rs.git", rev = "d343171f7ec85cc028674115c8df30150b741ef6" }
+streambed = { git = "https://github.com/streambed/streambed-rs.git", rev = "101908794bbe4448578a14b474d6a948387c963a" }
+streambed-confidant = { git = "https://github.com/streambed/streambed-rs.git", rev = "101908794bbe4448578a14b474d6a948387c963a" }
+streambed-logged = { git = "https://github.com/streambed/streambed-rs.git", rev = "101908794bbe4448578a14b474d6a948387c963a" }
+streambed-storage = { git = "https://github.com/streambed/streambed-rs.git", rev = "101908794bbe4448578a14b474d6a948387c963a" }
 test-log = "0.2.11"
 tokio = "1.23.0"
 tokio-stream = "0.1.14"


### PR DESCRIPTION
I updated Streambed today and streamlined some of its feature declarations around Tokio and also now avoids OpenSSL unless really required.
