### PR TITLE
Make Fossa workflow Rust specific; lock GH action versions

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -18,21 +18,15 @@ jobs:
         # https://github.com/actions/checkout/releases
         # v4.1.0
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-        with:
-          # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
-          fetch-depth: 0
 
-      - name: Cache Coursier cache
-        # https://github.com/coursier/cache-action/releases
-        # v6.4.3
-        uses: coursier/cache-action@d1039466d0812d6370649b9afb02bbf5f646bacf
+      - name: Update Rust
+        run: |
+          rustup update
 
-      - name: Set up JDK 11
-        # https://github.com/coursier/setup-action/releases
-        # v1.3.4
-        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
-        with:
-          jvm: temurin:1.11
+      - name: Cache Rust
+        # https://github.com/Swatinem/rust-cache/releases
+        # v2.7.0
+        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
 
       - name: FOSSA policy check
         run: |-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,21 +13,31 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
-
+    runs-on: ubuntu-22.04
     env:
       RUSTFLAGS: -Dwarnings
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      # https://github.com/actions/checkout/releases
+      # v4.1.0
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+
     - name: Update Rust
       run: |
         rustup update
+
     - name: Install protoc
-      uses: taiki-e/install-action@v2
+      # https://github.com/taiki-e/install-action/releases
+      # v2.20.3
+      uses: taiki-e/install-action@47d27149ff6b3422864ec504071d5cc7873d642e
       with:
         tool: protoc@${{ env.PROTOC_VERSION }}
-    - uses: Swatinem/rust-cache@v2
+
+    - name: Cache Rust
+      # https://github.com/Swatinem/rust-cache/releases
+      # v2.7.0
+      uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
 
     - name: test
       run: |


### PR DESCRIPTION
First after merging it appeared to me that we don't need a JVM in the Fossa workflow.

Took the chance to lock GitHub actions to hash versions for security reasons.