### PR TITLE
Save offsets on the consumer and correctly uses entity id

### DIFF
--- a/akka-projection-rs-grpc/src/producer.rs
+++ b/akka-projection-rs-grpc/src/producer.rs
@@ -494,7 +494,5 @@ mod tests {
         assert!(!consumer_filters_receiver.borrow().is_empty());
 
         assert!(reply_receiver.await.is_ok());
-
-        server_kill_switch.notified();
     }
 }


### PR DESCRIPTION
Consumer offsets were not being saved. They now are.

Also, we were incorrectly using the persistence id in place of where an entity id was expected. This was causing a parsing issue and preventing an event from being saved correctly.

Fixes #48 
Fixes #49
Fixes #51