### PR TITLE
Docs generation requires protobuf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,13 @@ jobs:
         run: |
           rustup update
 
+      - name: Install protoc
+        # https://github.com/taiki-e/install-action/releases
+        # v2.20.3
+        uses: taiki-e/install-action@47d27149ff6b3422864ec504071d5cc7873d642e
+        with:
+          tool: protoc@${{ env.PROTOC_VERSION }}
+
       - name: Cache Rust
         # https://github.com/Swatinem/rust-cache/releases
         # v2.7.0


### PR DESCRIPTION
```
  Could not find `protoc` installation and this build crate cannot proceed without
      this knowledge. If `protoc` is installed and this crate had trouble finding
      it, you can set the `PROTOC` environment variable with the specific path to your
      installed `protoc` binary.If you're on debian, try `apt-get install protobuf-compiler` or download it from https://github.com/protocolbuffers/protobuf/releases
```

References 
- #54 
- #55 