### PR TITLE
Throttle connections

### DIFF
--- a/akka-projection-rs-grpc/src/delayer.rs
+++ b/akka-projection-rs-grpc/src/delayer.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use exponential_backoff::Backoff;
 use tokio::time;
 
-const MIN_DELAY: Duration = Duration::from_millis(100);
+const MIN_DELAY: Duration = Duration::from_millis(500);
 const MAX_DELAY: Duration = Duration::from_secs(10);
 
 pub struct Delayer {

--- a/akka-projection-rs-grpc/src/producer.rs
+++ b/akka-projection-rs-grpc/src/producer.rs
@@ -190,20 +190,21 @@ pub async fn run<E, EC, ECR>(
             break;
         }
 
+        if let Some(d) = &mut delayer {
+            d.delay().await;
+        } else {
+            let mut d = Delayer::default();
+            d.delay().await;
+            delayer = Some(d);
+        }
+
         let mut connection = if let Ok(connection) = (event_consumer_channel)()
             .await
             .map(proto::event_consumer_service_client::EventConsumerServiceClient::new)
         {
-            delayer = None;
+            delayer = Some(Delayer::default());
             Some(connection)
         } else {
-            if let Some(d) = &mut delayer {
-                d.delay().await;
-            } else {
-                let mut d = Delayer::default();
-                d.delay().await;
-                delayer = Some(d);
-            }
             None
         };
 


### PR DESCRIPTION
Throttle back connections made both for consumer and producer instigated connections, even given previously successful connections.

Given that we allow the edge side to recover and try again:

Fixes #57 
Fixes #58 