### PR TITLE
build: remove akka-projection-rs-storage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,10 +65,6 @@ jobs:
       if: startsWith(github.event.ref, 'refs/tags/v')
       run: cargo publish --registry AKKA_RS -p akka-projection-rs-grpc
 
-    - name: Publish akka-projection-rs-storage
-      if: startsWith(github.event.ref, 'refs/tags/v')
-      run: cargo publish --registry AKKA_RS -p akka-projection-rs-storage
-
   documentation:
     if: github.event.repository.fork == false
     name: Documentation


### PR DESCRIPTION
* it was removed

All other modules were successfully published so version 0.2.0 should be fine anyway