### PR TITLE
Recover the last offset correctly

### DIFF
--- a/akka-persistence-rs/src/entity.rs
+++ b/akka-persistence-rs/src/entity.rs
@@ -51,4 +51,8 @@ pub trait EventSourcedBehavior {
     /// Any required side effects should be performed once recovery has completed by
     /// overriding this method.
     async fn on_recovery_completed(&self, _context: &Context, _state: &Self::State) {}
+
+    /// Called when the entity manager has completed initially recoverying entities,
+    /// even if there are no initial entities.
+    async fn on_initial_recovery_completed(&self) {}
 }

--- a/akka-persistence-rs/src/entity_manager.rs
+++ b/akka-persistence-rs/src/entity_manager.rs
@@ -192,6 +192,7 @@ where
                 .on_recovery_completed(&context, &entity_status.state)
                 .await;
         }
+        behavior.on_initial_recovery_completed().await;
     }
 
     // Receive commands for the entities and process them.


### PR DESCRIPTION
The change here principally fixes a bug with the new offset store where we weren't recovering the last offset. However, I then found a race condition where the consumer projection wasn't waiting for the offset store to finish its recovery. Further, the offset store had no means to convey that it had fully recovered, nor any entity manager for that matter. Consequently, a new `on_initial_recovery_completed` method has been added to the entity behaviour trait, and called by the entity manager.

Fixes #https://github.com/lightbend/akka-edge-rs/issues/86