### PR TITLE
bump: version 0.3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Publish API documentation (tag)
         if: startsWith(github.event.ref, 'refs/tags/v')
         env:
-          TAG: ${{ github.event.ref }}
+          REFS_TAG: ${{ github.event.ref }}
           AKKA_RSYNC_GUSTAV: ${{ secrets.AKKA_RSYNC_GUSTAV }}
           RSYNC_RSH: "ssh -o StrictHostKeyChecking=no"
         run: |+
@@ -109,6 +109,7 @@ jobs:
           chmod 600 .github/id_rsa
           ssh-add .github/id_rsa
           cd target/doc
+          TAG=$(echo $REFS_TAG | cut -d'/' -f 3)
           rsync -azP ./ akkarepo@gustav.akka.io:www/api/akka-edge-rs/${TAG}/
 
       - name: Publish API documentation (snapshot)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0" # WHEN UPDATING THIS VERSION, UPDATE THE `akka-persistence-rs` VERSIONS BELOW
+version = "0.3.0" # WHEN UPDATING THIS VERSION, UPDATE THE `akka-persistence-rs` VERSIONS BELOW
 edition = "2021"
 rust-version = "1.70.0"
 license-file = "LICENSE"
@@ -64,9 +64,9 @@ yew = { version = "0.20" }
 
 # THE VERSIONS HERE SHOULD BE THE SAME AS PER `workspace.package.version`.
 
-akka-persistence-rs = { path = "akka-persistence-rs", version = "0.2.0", registry = "lightbend-akka-rs" }
-akka-persistence-rs-commitlog = { path = "akka-persistence-rs-commitlog", version = "0.2.0", registry = "lightbend-akka-rs" }
-akka-projection-rs = { path = "akka-projection-rs", version = "0.2.0", registry = "lightbend-akka-rs" }
+akka-persistence-rs = { path = "akka-persistence-rs", version = "0.3.0", registry = "lightbend-akka-rs" }
+akka-persistence-rs-commitlog = { path = "akka-persistence-rs-commitlog", version = "0.3.0", registry = "lightbend-akka-rs" }
+akka-projection-rs = { path = "akka-projection-rs", version = "0.3.0", registry = "lightbend-akka-rs" }
 
 [profile.bench-debug]
 inherits = "release"


### PR DESCRIPTION
* and try to grab the tag correctly

but we can wait with the release until #88 has been completed, otherwise it would only be the `and_then` convenience