### PR TITLE
Marshal filtered events

### DIFF
--- a/akka-projection-rs-grpc/src/consumer.rs
+++ b/akka-projection-rs-grpc/src/consumer.rs
@@ -195,7 +195,20 @@ where
                                         yield envelope;
                                     }
 
-                                    Some(proto::stream_out::Message::FilteredEvent(_)) | None => ()
+                                    Some(proto::stream_out::Message::FilteredEvent(streamed_event)) => {
+                                        // Marshal and abort if we can't.
+
+                                        let Ok(envelope) = streamed_event.try_into() else {
+                                            warn!("Cannot marshal envelope. Aborting stream.");
+                                            break
+                                        };
+
+                                        // All is well, so emit the event.
+
+                                        yield envelope;
+                                    }
+
+                                    None => ()
                                 }
 
                                 Err(e) => {


### PR DESCRIPTION
Filtered events are now passed through to a handler. Handlers already check to determine whether an envelope's event is some... so things should just work there.

Fixes https://github.com/lightbend/akka-edge-rs/issues/108