### PR TITLE
Improve effects

### DIFF
--- a/akka-persistence-rs/src/effect.rs
+++ b/akka-persistence-rs/src/effect.rs
@@ -3,9 +3,10 @@
 //! to be applied (run) before the next command for an entity id is processed.
 //!
 //! Convience methods are providing for commonly chained operations, and take
-//! the form of `and_then` as the prefix. By Rust convention, `and_then`
+//! the form of `and_then` and `then` as the prefix. By Rust convention, `and_then`
 //! provides the result of the previous operation and expects a result provided
-//! given some closure.
+//! given some closure. Also by convention, `then` is applied only when the previous operation
+//! completed successfully.
 //!
 //! In the case where there is no convenience method, a generalized `and`
 //! operation can be used to chain any effect found here, or a customized


### PR DESCRIPTION
As a result of feedback, the reply and emit event effects have been refined in accordance with their common usage.

Here's `then_emit_event` now (applied only on success of the previous effect):

```rust
reply(reply_to, reply_value)
    .then_emit_event(|_s| Some(TestEvent))
```

Here's `then_reply` now (applied only on success of the previous effect):

```rust
emit_event(TestEvent)
    .then_reply(|_s| Some((reply_to, 123)))
```

I also found a bug where `.and` was only applying the RHS on the previous operation's success. This was a hangover from before passing the result around.

Finally, there are some reasonable tests for the effects.

Fixes #https://github.com/lightbend/akka-edge-rs/issues/105