### PR TITLE
Refactor "emit" to "persist"

### DIFF
--- a/akka-persistence-rs-commitlog/Cargo.toml
+++ b/akka-persistence-rs-commitlog/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 ciborium = { workspace = true, optional = true }
 itoa = { workspace = true }
+log = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 smol_str = { workspace = true }

--- a/akka-persistence-rs/benches/benches.rs
+++ b/akka-persistence-rs/benches/benches.rs
@@ -1,7 +1,7 @@
 use std::{io, num::NonZeroUsize, pin::Pin, sync::Arc};
 
 use akka_persistence_rs::{
-    effect::{emit_event, Effect, EffectExt},
+    effect::{persist_event, Effect, EffectExt},
     entity::{Context, EventSourcedBehavior},
     entity_manager::{self, EventEnvelope, Handler, SourceProvider},
     EntityId, Message,
@@ -32,7 +32,7 @@ impl EventSourcedBehavior for Behavior {
         _state: &Self::State,
         _command: Self::Command,
     ) -> Box<dyn Effect<Self>> {
-        emit_event(Event).boxed()
+        persist_event(Event).boxed()
     }
 
     fn on_event(_context: &Context, _state: &mut Self::State, _event: Self::Event) {}

--- a/akka-persistence-rs/src/entity.rs
+++ b/akka-persistence-rs/src/entity.rs
@@ -27,10 +27,10 @@ pub trait EventSourcedBehavior {
     type State: Default;
     /// The command(s) that are able to be processed by the entity.
     type Command;
-    /// The event emitted having performed an effect.
+    /// The event produced having performed an effect.
     type Event;
 
-    /// Given a state and command, optionally emit an effect that may cause an
+    /// Given a state and command, optionally produce an effect that may cause an
     /// event transition. Events are responsible for mutating state.
     /// State can also be associated with the behavior so that other effects can be
     /// performed. For example, a behavior might be created with a channel sender


### PR DESCRIPTION
Refactors "emit" as "persist" and attempts to convey the intention of associated operations that persistence is required.

As a consequence, the commit log marshaller is refactored to remove the optionality of some return types to support that all events must be persisted. Along the way, I also refactored some options into a result with increased error reporting and logging.

Fixes #94 
Fixes #96

Downstream: https://github.com/lightbend/akka-projection-temp/pull/19