### PR TITLE
Declare the size of a numeric entity id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Cargo.lock
 target
 .DS_Store
 dist
+.idea


### PR DESCRIPTION
Permits the number of bits to be used for describing an entity id to be declared explicitly, rather than assuming 32 bits. I found that using MAC addresses with 48 bits as entity ids is also useful, and still leaves plenty of bits for record types.

A const generic is used and so therefore there is no runtime penalty. I have included a runtime assertion to ensure that an entity id does not exceed the allocated number of bits.

This is a small breaking change and I have a PR pending for the sample.